### PR TITLE
fixing font type

### DIFF
--- a/api.md
+++ b/api.md
@@ -71,12 +71,12 @@ The output is similar to this:
       "serverAddress": "192.168.0.18:6443"
     }
   ]
-  ```
+```
   
-  ## Without kubectl proxy
+## Without kubectl proxy
   
   
-  ```
+```
   # Check all possible clusters, as you .KUBECONFIG may have multiple contexts:
 kubectl config view -o jsonpath='{"Cluster name\tServer\n"}{range .clusters[*]}{.name}{"\t"}{.cluster.server}{"\n"}{end}'
 


### PR DESCRIPTION
Fixing a  font type. Additional spaces in the source file is causing inappropriate visualization of the HTML file. 

<img width="262" alt="Screen Shot 2020-01-26 at 8 57 15 PM" src="https://user-images.githubusercontent.com/59834/73146026-7dde5080-407e-11ea-8afc-488749ab4cdc.png">
