### PR TITLE
Fixed preview readme syntax best practices

### DIFF
--- a/replicaset101/README.md
+++ b/replicaset101/README.md
@@ -136,7 +136,7 @@ metadata:
 spec:
   containers:
   - name: orphan
-	image: httpd
+    image: httpd
 ```
 
 It looks a lot like the other pods, but it is using Apache (httpd) instead of Nginx for an image. Using kubectl, we can apply this definition like:


### PR DESCRIPTION
When you copy and paste the best practices definition yaml to a new file and apply it, I received a syntax error, fixed in this commit.